### PR TITLE
Add Vendor Type to the list of qbxml models

### DIFF
--- a/lib/qbwc_requests.rb
+++ b/lib/qbwc_requests.rb
@@ -23,7 +23,8 @@ qbxml_models = [
   "item_subtotal",
   "job_report",
   "purchase_order",
-  "vendor"
+  "vendor",
+  "vendor_type"
 ]
 
 def camelize name

--- a/lib/qbwc_requests/vendor/v07/add.rb
+++ b/lib/qbwc_requests/vendor/v07/add.rb
@@ -22,6 +22,7 @@ module QbwcRequests
         field :notes
         field :is_vendor_eligible_for_1099
         field :open_balance
+        ref_to :vendor_type, 159
 
         validates :name, presence: true, length: { maximum: 41 }
         validates :company_name, length: { maximum: 41 }

--- a/lib/qbwc_requests/vendor/v07/mod.rb
+++ b/lib/qbwc_requests/vendor/v07/mod.rb
@@ -22,6 +22,7 @@ module QbwcRequests
         field :notes
         field :is_vendor_eligible_for_1099
         field :open_balance
+        ref_to :vendor_type, 159
 
         validates :name, presence: true, length: { maximum: 41 }
         validates :company_name, length: { maximum: 41 }

--- a/lib/qbwc_requests/vendor/v13/add.rb
+++ b/lib/qbwc_requests/vendor/v13/add.rb
@@ -22,6 +22,7 @@ module QbwcRequests
         field :notes
         field :is_vendor_eligible_for_1099
         field :open_balance
+        ref_to :vendor_type, 159
 
         validates :name, presence: true, length: { maximum: 41 }
         validates :company_name, length: { maximum: 41 }

--- a/lib/qbwc_requests/vendor/v13/mod.rb
+++ b/lib/qbwc_requests/vendor/v13/mod.rb
@@ -22,6 +22,7 @@ module QbwcRequests
         field :notes
         field :is_vendor_eligible_for_1099
         field :open_balance
+        ref_to :vendor_type, 159
 
         validates :name, length: { maximum: 41 }
         validates :company_name, length: { maximum: 41 }


### PR DESCRIPTION
Our Vendor Type class was left out of the list for qbxml models, this branch adds that class to the list.